### PR TITLE
fix: use single bucket for content bus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,8 +67,8 @@ async function main(request, context) {
   }, log);
 
   // fetch data from content bus
-  const key = `${contentBusPartition}${suffix}`;
-  const dataResponse = await fetchS3(contentBusId, key, log);
+  const key = `${contentBusId}/${contentBusPartition}${suffix}`;
+  const dataResponse = await fetchS3('helix-content-bus', key, log);
   if (dataResponse.status !== 200) {
     return dataResponse;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,8 +64,8 @@ describe('Index Tests', () => {
   it('fetches correct content', async () => {
     const { main: proxyMain } = proxyquire('../src/index.js', {
       './fetch-s3.js': async (bucketId, key) => {
-        assert.strictEqual(bucketId, 'foobar');
-        assert.strictEqual(key, 'preview/index.json');
+        assert.strictEqual(bucketId, 'helix-content-bus');
+        assert.strictEqual(key, 'foobar/preview/index.json');
         return new Response(JSON.stringify(TEST_SINGLE_SHEET), {
           status: 200,
           headers: {

--- a/test/post-deploy.js
+++ b/test/post-deploy.js
@@ -27,7 +27,7 @@ const MULTI_SHEET_PATH = '/data-embed-unit-tests/multisheet.json';
 
 const DEFAULT_PARAMS = {
   // https://adobe.sharepoint.com/sites/cg-helix/Shared%20Documents/Forms/AllItems.aspx
-  contentBusId: 'h3d4b1d4ea6d84b0229bce7cf6806b0bb3470489ab8205a13f75cfe518fa7',
+  contentBusId: 'd4b1d4ea6d84b0229bce7cf6806b0bb3470489ab8205a13f75cfe518fa7',
 };
 
 createTargets().forEach((target) => {


### PR DESCRIPTION
fixes #36

BREAKING CHANGE: content-bus id no longer addresses the bucket but is
  a prefix for the key in the helix-content-bus bucket

