### PR TITLE
feat: use new path format with contentBusPartition as path segment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ async function main(request, context) {
   }
   const {
     contentBusId,
-    contentBusPartition = 'live',
     limit,
     offset,
     sheet,
@@ -67,7 +66,7 @@ async function main(request, context) {
   }, log);
 
   // fetch data from content bus
-  const key = `${contentBusId}/${contentBusPartition}${suffix}`;
+  const key = `${contentBusId}${suffix}`;
   const dataResponse = await fetchS3('helix-content-bus', key, log);
   if (dataResponse.status !== 200) {
     return dataResponse;
@@ -79,5 +78,4 @@ async function main(request, context) {
 
 module.exports.main = wrap(main)
   .with(statusWrap)
-  .with(logger.trace)
   .with(logger);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,7 +45,7 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://json-filter.com/?contentBusId=foobar'), {
       log: console,
       pathInfo: {
-        suffix: '/index.md',
+        suffix: '/preview/index.md',
       },
     });
     assert.strictEqual(result.status, 400);
@@ -55,7 +55,7 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://json-filter.com/?contentBusId=foobar'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(result.status, 400);
@@ -75,10 +75,10 @@ describe('Index Tests', () => {
       },
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&limit=10&offset=5'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&limit=10&offset=5'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 200);
@@ -99,10 +99,10 @@ describe('Index Tests', () => {
       './fetch-s3.js': async () => new Response('', { status: 404 }),
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&limit=10&offset=5'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&limit=10&offset=5'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 404);
@@ -119,10 +119,10 @@ describe('Index Tests', () => {
       './json-filter.js': () => () => new Response('', { status: 404 }),
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&limit=10&offset=5'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&limit=10&offset=5'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 404);
@@ -144,10 +144,10 @@ describe('Index Tests', () => {
       },
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&limit=10'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&limit=10'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 200);
@@ -169,10 +169,10 @@ describe('Index Tests', () => {
       },
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&offset=10'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&offset=10'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 200);
@@ -194,10 +194,10 @@ describe('Index Tests', () => {
       },
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&sheet=sheet1&sheet=sheet2'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&sheet=sheet1&sheet=sheet2'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 200);
@@ -219,10 +219,10 @@ describe('Index Tests', () => {
       },
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&sheet=sheet1'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&sheet=sheet1'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 200);
@@ -238,10 +238,10 @@ describe('Index Tests', () => {
       }),
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&sheet=countries&offset=2&limit=1'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&sheet=countries&offset=2&limit=1'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 502);
@@ -258,10 +258,10 @@ describe('Index Tests', () => {
       }),
     });
 
-    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&contentBusPartition=preview&sheet=countries&offset=2&limit=1'), {
+    const resp = await proxyMain(new Request('https://json-filter.com/?contentBusId=foobar&sheet=countries&offset=2&limit=1'), {
       log: console,
       pathInfo: {
-        suffix: '/index.json',
+        suffix: '/preview/index.json',
       },
     });
     assert.strictEqual(resp.status, 502);

--- a/test/post-deploy.js
+++ b/test/post-deploy.js
@@ -33,7 +33,7 @@ const DEFAULT_PARAMS = {
 createTargets().forEach((target) => {
   describe(`Post-Deploy Tests (${target.title()})`, () => {
     it('filters a single sheet', async () => {
-      const path = `${target.urlPath()}${SINGLE_SHEET_PATH}?${querystring.encode({
+      const path = `${target.urlPath()}/live${SINGLE_SHEET_PATH}?${querystring.encode({
         ...DEFAULT_PARAMS,
         limit: 4,
       })}`;
@@ -68,7 +68,7 @@ createTargets().forEach((target) => {
     }).timeout(50000);
 
     it('filters a multi sheet', async () => {
-      const path = `${target.urlPath()}${MULTI_SHEET_PATH}?${querystring.encode({
+      const path = `${target.urlPath()}/live${MULTI_SHEET_PATH}?${querystring.encode({
         ...DEFAULT_PARAMS,
         limit: 1,
       })}`;
@@ -119,7 +119,7 @@ createTargets().forEach((target) => {
     }).timeout(50000);
 
     it('selects single sheet from a multi sheet', async () => {
-      const path = `${target.urlPath()}${MULTI_SHEET_PATH}?${querystring.encode({
+      const path = `${target.urlPath()}/live${MULTI_SHEET_PATH}?${querystring.encode({
         ...DEFAULT_PARAMS,
         limit: 1,
         sheet: '日本',
@@ -151,7 +151,7 @@ createTargets().forEach((target) => {
     }).timeout(50000);
 
     it('selects wrong sheet from a multi sheet', async () => {
-      const path = `${target.urlPath()}${MULTI_SHEET_PATH}?${querystring.encode({
+      const path = `${target.urlPath()}/live${MULTI_SHEET_PATH}?${querystring.encode({
         ...DEFAULT_PARAMS,
         limit: 1,
         sheet: 'does-not-exist',
@@ -180,7 +180,7 @@ createTargets().forEach((target) => {
      * alternatively, it could always respond with 404 if a sheet selector is specified.
      */
     it('selects sheet from a single sheet', async () => {
-      const path = `${target.urlPath()}${SINGLE_SHEET_PATH}?${querystring.encode({
+      const path = `${target.urlPath()}/live${SINGLE_SHEET_PATH}?${querystring.encode({
         ...DEFAULT_PARAMS,
         limit: 1,
         sheet: 'does-not-exist',


### PR DESCRIPTION
BREAKING CHANGE: in order to have a similar path format as the
  pipeline-service, the json-filter requires now also the
  contentBusPartition as path segment, eg: /live/path

